### PR TITLE
Search all panes when opening a file

### DIFF
--- a/lib/elixir-jump-around.js
+++ b/lib/elixir-jump-around.js
@@ -23,10 +23,11 @@ export default {
 
   toggle_test_file() {
     currentFilePath = atom.workspace.getActiveTextEditor().getPath();
+    opts = {searchAllPanes: true}
     if (this.isTestFilePath(currentFilePath)) {
-      return atom.workspace.open(this.getModulePath(currentFilePath));
+      return atom.workspace.open(this.getModulePath(currentFilePath), opts);
     } else {
-      return atom.workspace.open(this.getTestPath(currentFilePath));
+      return atom.workspace.open(this.getTestPath(currentFilePath), opts);
     }
   },
 


### PR DESCRIPTION
Utilizes the `searchAllPanes` option when opening a file, which will focus the editor if the test or module file is already open on another tab.

Docs: https://atom.io/docs/api/v1.39.0/Workspace#instance-open